### PR TITLE
Update Required Version to 5.4

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation
 Prerequisites
 -------------
 
-Phormium requires PHP 5.3 or greater with the PDO_ extension loaded, as well as
+Phormium requires PHP 5.4 or greater with the PDO_ extension loaded, as well as
 any PDO drivers for databases to wich you wish to connect.
 
 .. _PDO: http://php.net/manual/en/book.pdo.php


### PR DESCRIPTION
Config uses short array syntax, not available until version 5.4.
http://php.net/manual/en/migration54.new-features.php
